### PR TITLE
'courses' and 'bookings' migration file should be create after 'users…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'font-awesome-sass'
 gem 'simple_form'
 gem 'devise'
 
+# Custom
+gem 'faker'
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    date (3.0.0)
     devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -90,6 +91,8 @@ GEM
       railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.7.0)
+    faker (2.18.0)
+      i18n (>= 1.6, < 2)
     ffi (1.15.3)
     font-awesome-sass (5.15.1)
       sassc (>= 1.11)
@@ -113,8 +116,6 @@ GEM
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.8)
-    nokogiri (1.12.3-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.12.3-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -237,8 +238,10 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  date
   devise
   dotenv-rails
+  faker
   font-awesome-sass
   jbuilder (~> 2.7)
   listen (~> 3.2)

--- a/db/migrate/20210816101222_create_chef_profiles.rb
+++ b/db/migrate/20210816101222_create_chef_profiles.rb
@@ -1,7 +1,7 @@
 class CreateChefProfiles < ActiveRecord::Migration[6.0]
   def change
     create_table :chef_profiles do |t|
-      t.Integer :years_exp
+      t.integer :years_exp
       t.references :user, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20210816110235_create_courses.rb
+++ b/db/migrate/20210816110235_create_courses.rb
@@ -4,8 +4,8 @@ class CreateCourses < ActiveRecord::Migration[6.0]
       t.string :name
       t.string :description
       t.string :cuisine_type
-      t.Integer :duration
-      t.Integer :price
+      t.integer :duration
+      t.integer :price
       t.references :chef_profile, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20210816110752_create_bookings.rb
+++ b/db/migrate/20210816110752_create_bookings.rb
@@ -1,9 +1,9 @@
 class CreateBookings < ActiveRecord::Migration[6.0]
   def change
     create_table :bookings do |t|
-      t.Date :date
-      t.Integer :time_slot
-      t.Integer :status
+      t.date :date
+      t.integer :time_slot
+      t.integer :status
       t.references :course, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,42 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_16_094836) do
+ActiveRecord::Schema.define(version: 2021_08_16_110752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bookings", force: :cascade do |t|
+    t.date "date"
+    t.integer "time_slot"
+    t.integer "status"
+    t.bigint "course_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["course_id"], name: "index_bookings_on_course_id"
+    t.index ["user_id"], name: "index_bookings_on_user_id"
+  end
+
+  create_table "chef_profiles", force: :cascade do |t|
+    t.integer "years_exp"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_chef_profiles_on_user_id"
+  end
+
+  create_table "courses", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.string "cuisine_type"
+    t.integer "duration"
+    t.integer "price"
+    t.bigint "chef_profile_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["chef_profile_id"], name: "index_courses_on_chef_profile_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,4 +59,8 @@ ActiveRecord::Schema.define(version: 2021_08_16_094836) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookings", "courses"
+  add_foreign_key "bookings", "users"
+  add_foreign_key "chef_profiles", "users"
+  add_foreign_key "courses", "chef_profiles"
 end


### PR DESCRIPTION
'courses' and 'bookings' migration file should be create after 'users' and 'chef_profiles'. This will cause an error when runs db:migrate, because courses and bookings has dependency on users and chef_profiles table (bookings should be after courses as well), needs to create new migration files to fix the order. Integer and Date data type in migration file are also invalid (should be lower case). The last picture is the result of db:migrate after I fixed it.
![image](https://user-images.githubusercontent.com/78134040/129555361-3a30a861-8f1d-46f8-813d-cd682192b221.png)
![image](https://user-images.githubusercontent.com/78134040/129555409-5154e440-33e6-42bd-aeab-41d79ab8817c.png)
![image](https://user-images.githubusercontent.com/78134040/129555447-d75e68c4-01f5-4a1e-aea3-0641133b96cb.png)
![image](https://user-images.githubusercontent.com/78134040/129555521-90c890ef-b04f-47d2-9c0c-154069e329c2.png)
