### PR TITLE
Add name to signup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   # [...]
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
   include Pundit
 
   # Pundit: white-list approach.
@@ -13,6 +14,14 @@ class ApplicationController < ActionController::Base
   #   flash[:alert] = "You are not authorized to perform this action."
   #   redirect_to(root_path)
   # end
+
+  def configure_permitted_parameters
+    # For additional fields in app/views/devise/registrations/new.html.erb
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name])
+
+    # For additional in app/views/devise/registrations/edit.html.erb
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name])
+  end
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,5 +16,5 @@ class User < ApplicationRecord
   end
 
   validates :email, presence: true
-  validates :password, presence: true
+  # validates :password, presence: true
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,6 +4,8 @@
     <%= f.error_notification %>
     <div class="form-inputs">
       <%= f.input :email, required: true, autofocus: true %>
+      <%= f.input :first_name, required: false, autofocus: true %>
+      <%= f.input :last_name, required: false, autofocus: true %>
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
         <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
       <% end %>
@@ -12,7 +14,7 @@
                 required: false,
                 input_html: { autocomplete: "new-password" } %>
       <%= f.input :password_confirmation,
-                required: false,
+
                 input_html: { autocomplete: "new-password" } %>
       <%= f.input :current_password,
                 hint: "we need your current password to confirm your changes",

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -14,7 +14,7 @@
                 required: false,
                 input_html: { autocomplete: "new-password" } %>
       <%= f.input :password_confirmation,
-
+                required: false,
                 input_html: { autocomplete: "new-password" } %>
       <%= f.input :current_password,
                 hint: "we need your current password to confirm your changes",

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,6 +7,14 @@
                 required: true,
                 autofocus: true,
                 input_html: { autocomplete: "email" }%>
+      <%= f.input :first_name,
+                required: false,
+                autofocus: true,
+                input_html: { autocomplete: "first name" }%>
+      <%= f.input :last_name,
+                required: false,
+                autofocus: true,
+                input_html: { autocomplete: "last name" }%>
       <%= f.input :password,
                 required: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),

--- a/db/migrate/20210818100423_add_name_to_users.rb
+++ b/db/migrate/20210818100423_add_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddNameToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_16_110752) do
+ActiveRecord::Schema.define(version: 2021_08_18_100423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,8 @@ ActiveRecord::Schema.define(version: 2021_08_16_110752) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Sign up now allows _new_ users to optionally input their first and last name. _Old_ users can now add a first and last name to their user profile (or edit their current ones) via the user edit view found at `/users/edit`.

Signup form with name fields:
<img width="1243" alt="Screen Shot 2021-08-18 at 19 40 32" src="https://user-images.githubusercontent.com/31387233/129896753-cbe46f5d-3bdb-4ce7-a739-ac2f1e2f9910.png">

Signup with name inputs filled:
<img width="1213" alt="Screen Shot 2021-08-18 at 19 42 29" src="https://user-images.githubusercontent.com/31387233/129896781-3144bcd1-0790-4b25-bc2e-a3e0659f3456.png">

Confirmation that the name parameters save to the user and that first and last name are not required for a new user:
<img width="817" alt="Screen Shot 2021-08-18 at 19 44 23" src="https://user-images.githubusercontent.com/31387233/129897035-1c2a07b0-da24-41d4-9565-1221f8638775.png">

Old user adding a first and last name to their profile (as well as changing their registered email):
<img width="1298" alt="Screen Shot 2021-08-18 at 19 54 57" src="https://user-images.githubusercontent.com/31387233/129897924-44e182f6-b093-4709-913b-c3894ec05a13.png">

User instance confirmation:
<img width="815" alt="Screen Shot 2021-08-18 at 21 08 17" src="https://user-images.githubusercontent.com/31387233/129898008-3ddf85b0-7367-4523-95a5-8ac6eb5b34b1.png">