### PR TITLE
Implement cloudinary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-debug.log*
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'pundit'
 
 # Custom
 gem 'faker'
+gem 'cloudinary', '~> 1.16.0'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (10.2.5.0)
       execjs (< 2.8.0)
+    aws_cf_signer (0.1.3)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.7.7)
@@ -75,6 +76,9 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    cloudinary (1.16.1)
+      aws_cf_signer
+      rest-client
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
@@ -84,6 +88,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -97,6 +103,9 @@ GEM
       sassc (>= 1.11)
     globalid (0.5.2)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
@@ -111,9 +120,13 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0704)
     mini_mime (1.1.0)
     minitest (5.14.4)
     msgpack (1.4.2)
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
@@ -174,6 +187,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -210,6 +228,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -241,6 +262,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  cloudinary (~> 1.16.0)
   devise
   dotenv-rails
   faker

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -9,6 +9,7 @@
     <% @description = course.description %>
     <% @price = "¥#{course.price}" %>
     <% @cuisine_type = course.cuisine_type %>
+    <% @course = course %>
     <%= link_to course_path(course) do %>
       <% render 'shared/course-card' %>
     <% end %>

--- a/app/views/dashboard/bookings/index.html.erb
+++ b/app/views/dashboard/bookings/index.html.erb
@@ -11,6 +11,7 @@
       <% @description = "#{booking.date} / #{booking.time_slot}" %>
       <% @price = booking.status %>
       <% @cuisine_type = booking.course.cuisine_type %>
+      <% @course = booking.course %>
       <%= link_to course_path(booking.course) do %>
         <%= render 'shared/course-card' %>
       <% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -24,6 +24,7 @@
                 <% @title = course.name %>
                 <% @description = "" %>
                 <% @price = "¥#{course.price}" %>
+                <% @course = course %>
                 <%= link_to course_path(course) do %>
                   <% render 'shared/square-card' %>
                 <% end %>

--- a/app/views/shared/_course-card.html.erb
+++ b/app/views/shared/_course-card.html.erb
@@ -7,6 +7,6 @@
       <p><%= @description %></p>
     </div>
     <h2 class="card-trip-text-padding"><%= @price %></h2>
-    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
+    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.chef_profile.user_id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
   </div>
 </div>

--- a/app/views/shared/_course-card.html.erb
+++ b/app/views/shared/_course-card.html.erb
@@ -1,5 +1,5 @@
 <div class="card-trip mb-3 d-flex flex-column justify-content-between">
-  <img src="https://source.unsplash.com/800x500/?food-<%= @title.split[0] %>" />
+  <%= cl_image_tag("https://source.unsplash.com/800x500/?food-'#{@title.split[-2]}'", :type=>"fetch") %>
   <div class="card-trip-infos">
     <div class="card-text-wrap text-truncate">
       <h2><%= @title %></h2>
@@ -7,6 +7,6 @@
       <p><%= @description %></p>
     </div>
     <h2 class="card-trip-text-padding"><%= @price %></h2>
-    <img src="https://source.unsplash.com/100x100/?face-<%= rand(100) %>" class="card-trip-user avatar-bordered" />
+    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
   </div>
 </div>

--- a/app/views/shared/_course-confirm-card.html.erb
+++ b/app/views/shared/_course-confirm-card.html.erb
@@ -19,6 +19,6 @@
     <% else %>
       <h2 class="card-trip-text-padding"><%= booking.status %></h2>
     <% end %>
-    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{booking.course.id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
+    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{booking.chef_profile.user_id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
   </div>
 </div>

--- a/app/views/shared/_course-confirm-card.html.erb
+++ b/app/views/shared/_course-confirm-card.html.erb
@@ -1,5 +1,5 @@
 <div class="card-trip mb-3 d-flex flex-column justify-content-between">
-  <img src="https://source.unsplash.com/800x500/?food-<%= booking.course.name.split.join('-') %>" />
+  <%= cl_image_tag("https://source.unsplash.com/800x500/?food-'#{booking.course.name.split[-2]}'", :type=>"fetch") %>
   <div class="card-trip-infos">
     <div class="card-text-wrap text-truncate">
       <h2><%=  booking.course.name %></h2>
@@ -19,6 +19,6 @@
     <% else %>
       <h2 class="card-trip-text-padding"><%= booking.status %></h2>
     <% end %>
-    <img src="https://source.unsplash.com/100x100/?chef-kitchen-<%= rand(100) %>" class="card-trip-user avatar-bordered" />
+    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{booking.course.id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
   </div>
 </div>

--- a/app/views/shared/_fullpage-card.erb
+++ b/app/views/shared/_fullpage-card.erb
@@ -1,5 +1,5 @@
 <div class="card-trip mb-3 d-flex flex-column justify-content-between" id="card-trip-flow">
-  <img src="https://source.unsplash.com/800x500/?food-<%= @title.split[0] %>" />
+  <%= cl_image_tag("https://source.unsplash.com/800x500/?food-'#{@title.split[-2]}'", :type=>"fetch") %>
   <div class="card-trip-infos">
     <div class="card-text">
       <h2><%= @title %></h2>
@@ -7,6 +7,6 @@
       <p><%= @description %></p>
     </div>
     <h2 class="card-trip-text-padding"><%= @price %></h2>
-    <img src="https://source.unsplash.com/100x100/?face-<%= rand(100) %>" class="card-trip-user avatar-bordered" />
+    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
   </div>
 </div>

--- a/app/views/shared/_fullpage-card.erb
+++ b/app/views/shared/_fullpage-card.erb
@@ -7,6 +7,6 @@
       <p><%= @description %></p>
     </div>
     <h2 class="card-trip-text-padding"><%= @price %></h2>
-    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
+    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.chef_profile.user_id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
   </div>
 </div>

--- a/app/views/shared/_square-card.html.erb
+++ b/app/views/shared/_square-card.html.erb
@@ -5,6 +5,6 @@
       <h2><%= @title %></h2>
     </div>
     <h2 class="card-trip-text-padding"><%= @price %></h2>
-    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
+    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.chef_profile.user_id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
   </div>
 </div>

--- a/app/views/shared/_square-card.html.erb
+++ b/app/views/shared/_square-card.html.erb
@@ -1,10 +1,10 @@
 <div class="card-trip mb-3 d-flex flex-column justify-content-between">
-  <img src="https://source.unsplash.com/800x500/?food-<%= @title.split[0] %>" />
+  <%= cl_image_tag("https://source.unsplash.com/800x500/?food-'#{@title.split[-2]}'", :type=>"fetch") %>
   <div class="card-trip-infos">
     <div class="card-text-wrap">
       <h2><%= @title %></h2>
     </div>
     <h2 class="card-trip-text-padding"><%= @price %></h2>
-    <img src="https://source.unsplash.com/100x100/?face-<%= rand(100) %>" class="card-trip-user avatar-bordered" />
+    <%= cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.id}'", :type=>"fetch", class: "card-trip-user avatar-bordered") %>
   </div>
 </div>


### PR DESCRIPTION
Cloudinary has been configured. All HTML image tags have been changed to cloudinary fetch tags. 

The immediate benefit of this is that our pictures (avatars included) are static and no longer change on reload. A further benefit is that we can actually tell what chef made a course by the course's avatar image.

<img width="1030" alt="Screen Shot 2021-08-19 at 01 30 34" src="https://user-images.githubusercontent.com/31387233/129936636-efd90591-f39e-4b91-aa61-8fde7e1fe963.png">

<img width="1158" alt="Screen Shot 2021-08-19 at 01 29 14" src="https://user-images.githubusercontent.com/31387233/129936673-9c93a20b-df94-48c8-bcb2-890efda54f1e.png">

<img width="1150" alt="Screen Shot 2021-08-19 at 01 28 58" src="https://user-images.githubusercontent.com/31387233/129936697-38dd14ad-ab2f-48fa-b200-ef1570cf362e.png">
