### PR TITLE
Rails is where magic happens.

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -34,7 +34,7 @@ class CoursesController < ApplicationController
     if @course.save
       redirect_to chef_profile_path(@chef_profile), notice: 'Course was successfully created.'
     else
-      redirect_to chef_profile_path(@chef_profile), alert: 'Failed to create course.'
+      redirect_to chef_profile_path(@chef_profile), alert: "Failed to create course. #{@course.errors.full_messages.join(', ')}."
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,6 +12,7 @@ class Course < ApplicationRecord
   validates :cuisine_type, presence: true
   validates :duration, presence: true
   validates :price, presence: true
+  validates :photo, presence: true
 
   include PgSearch::Model
     pg_search_scope :search_by_name_and_description,

--- a/app/views/chef_profiles/show.html.erb
+++ b/app/views/chef_profiles/show.html.erb
@@ -7,17 +7,19 @@
     <% if chef.user.photo.attached? %>
       <%= cl_image_tag(chef.user.photo.key, class: "rounded-circle", width: 200, height: 200) %>
     <% else %>
-      <% initial = chef.user.first_name.nil? ? "X" : chef.user.first_name[0].upcase; %>
+      <% initial = chef.user.first_name.nil? ? chef.user.email[0].upcase : chef.user.first_name[0].upcase; %>
       <%= cl_image_tag("https://dummyimage.com/200x200/fff/000&text=#{initial}",
       type: "fetch", class: "rounded-circle") %>
     <% end %>
   </div>
   <p><strong>Experience: </strong><%= chef.years_exp %> Years</p>
-  <p><strong>Your courses:</strong></p>
-  <!-- Button trigger modal -->
-  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#createCourse">
-    Create New Course
-  </button>
+  <div class="d-flex justify-content-between">
+    <p><strong>Your courses:</strong></p>
+    <!-- Button trigger modal -->
+    <button type="button" class="btn btn-primary mb-3" data-toggle="modal" data-target="#createCourse">
+      Create New Course
+    </button>
+  </div>
   <!-- Modal -->
   <div class="modal fade" id="createCourse" tabindex="-1" aria-labelledby="createCourseLabel" aria-hidden="true">
     <div class="modal-dialog">
@@ -35,6 +37,7 @@
             <%= f.input :cuisine_type, collection: Course::CUISINES.map { |str| str.capitalize }, include_blank: false %>
             <%= f.input :duration, include_blank: false %>
             <%= f.input :price, include_blank: false %>
+            <%= f.input :photo %>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
@@ -46,7 +49,13 @@
   </div>
   <% chef.courses.each do |course| %>
     <%= link_to course_path(course) do %>
-      <li><%= course.name %></li>
+      <% header_image_tag = course.photo.attached? ? cl_image_tag(course.photo.key)
+      : cl_image_tag("https://dummyimage.com/1000x500/fff/000&text=Sorry!%20No%20photo%20attached",type: "fetch") %>
+      <% user_image_tag = course.chef_profile.user.photo.attached? ? cl_image_tag(course.chef_profile.user.photo.key, class: "card-trip-user avatar-bordered")
+      : cl_image_tag("https://dummyimage.com/200x200/fff/000&text=#{initial}",type: "fetch", class: "card-trip-user avatar-bordered") %>
+      <%= render 'shared/course-card', header_image_tag: header_image_tag, title: course.name,
+      sub_title: course.cuisine_type, description: course.description, status: "¥#{number_with_delimiter(course.price)}",
+      user_image_tag: user_image_tag %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -8,7 +8,7 @@
     <%= link_to course_path(course) do %>
       <% header_image_tag = course.photo.attached? ? cl_image_tag(course.photo.key)
       : cl_image_tag("https://source.unsplash.com/800x500/?food-'#{course.name.split[-2]}'", :type=>"fetch") %>
-      <% render 'shared/course-card', title: course.name, status: "¥#{course.price}", 
+      <% render 'shared/course-card', title: course.name, status: "¥#{number_with_delimiter(course.price)}", 
       description: course.description, sub_title: course.cuisine_type,
       header_image_tag: header_image_tag,
       user_image_url: "https://source.unsplash.com/100x100/?face-'#{course.chef_profile.user_id}'" %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -6,12 +6,14 @@
   <% end %>
   <% @courses.each do |course| %>
     <%= link_to course_path(course) do %>
+      <% initial = course.chef_profile.user.first_name.nil? ? course.chef_profile.user.email[0].upcase : course.chef_profile.user.first_name[0].upcase; %>
       <% header_image_tag = course.photo.attached? ? cl_image_tag(course.photo.key)
-      : cl_image_tag("https://source.unsplash.com/800x500/?food-'#{course.name.split[-2]}'", :type=>"fetch") %>
+      : cl_image_tag("https://dummyimage.com/1000x500/fff/000&text=Sorry!%20No%20photo%20attached",type: "fetch") %>
+      <% user_image_tag = course.chef_profile.user.photo.attached? ? cl_image_tag(course.chef_profile.user.photo.key, class: "card-trip-user avatar-bordered")
+      : cl_image_tag("https://dummyimage.com/200x200/fff/000&text=#{initial}",type: "fetch", class: "card-trip-user avatar-bordered") %>
       <% render 'shared/course-card', title: course.name, status: "¥#{number_with_delimiter(course.price)}", 
       description: course.description, sub_title: course.cuisine_type,
-      header_image_tag: header_image_tag,
-      user_image_url: "https://source.unsplash.com/100x100/?face-'#{course.chef_profile.user_id}'" %>
+      header_image_tag: header_image_tag, user_image_tag: user_image_tag %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,11 +1,14 @@
 <div class="container">
   <h1><%= @course.name %></h1>
+  <% initial = @course.chef_profile.user.first_name.nil? ? @course.chef_profile.user.email[0].upcase : @course.chef_profile.user.first_name[0].upcase; %>
   <% header_image_tag = @course.photo.attached? ? cl_image_tag(@course.photo.key)
-      : cl_image_tag("https://source.unsplash.com/800x500/?food-'#{@course.name.split[-2]}'", :type=>"fetch") %>
+      : cl_image_tag("https://dummyimage.com/1000x500/fff/000&text=Sorry!%20No%20photo%20attached",type: "fetch") %>
+  <% user_image_tag = @course.chef_profile.user.photo.attached? ? cl_image_tag(@course.chef_profile.user.photo.key, class: "card-trip-user avatar-bordered")
+      : cl_image_tag("https://dummyimage.com/200x200/fff/000&text=#{initial}",type: "fetch", class: "card-trip-user avatar-bordered") %>
   <%= render 'shared/fullpage-card', title: @course.name, status: "¥#{number_with_delimiter(@course.price)}", 
       description: @course.description, sub_title: @course.cuisine_type,
       header_image_tag: header_image_tag,
-      user_image_url: "https://source.unsplash.com/100x100/?face-'#{@course.chef_profile.user_id}'" %>
+      user_image_tag: user_image_tag %>
   <% if current_user != @course.chef_profile.user %>
     <h2>Book this course</h2>
     <%= render 'bookings/form' %>
@@ -17,7 +20,9 @@
   <% end %>
   <h2 class="mt-3">Brought to you by...</h2>
   <% chef_name = @course.chef_profile.user.first_name || @course.chef_profile.user.email.split('@')[0] %>
-  <%= render 'shared/chef-information-card', title: chef_name, status: "Neo Tokyo", 
+  <% header_avatar_tag = @course.chef_profile.user.photo.attached? ? cl_image_tag(@course.chef_profile.user.photo.key, gravity: :face)
+      : cl_image_tag("https://dummyimage.com/1000x500/fff/000&text=#{initial}",type: "fetch") %>
+  <%= render 'shared/chef-information-card', title: chef_name, status: @course.chef_profile.user.city, 
       sub_title: "#{@course.chef_profile.years_exp} years of experience",
-      header_image_tag: cl_image_tag("https://source.unsplash.com/100x100/?face-'#{@course.chef_profile.user_id}'", :type=>"fetch") %>
+      header_avatar_tag: header_avatar_tag %>
 </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -2,7 +2,7 @@
   <h1><%= @course.name %></h1>
   <% header_image_tag = @course.photo.attached? ? cl_image_tag(@course.photo.key)
       : cl_image_tag("https://source.unsplash.com/800x500/?food-'#{@course.name.split[-2]}'", :type=>"fetch") %>
-  <%= render 'shared/fullpage-card', title: @course.name, status: "¥#{@course.price}", 
+  <%= render 'shared/fullpage-card', title: @course.name, status: "¥#{number_with_delimiter(@course.price)}", 
       description: @course.description, sub_title: @course.cuisine_type,
       header_image_tag: header_image_tag,
       user_image_url: "https://source.unsplash.com/100x100/?face-'#{@course.chef_profile.user_id}'" %>

--- a/app/views/shared/_carousel-course.html.erb
+++ b/app/views/shared/_carousel-course.html.erb
@@ -7,7 +7,7 @@
             <%= link_to course_path(course) do %>
               <% header_image_tag = course.photo.attached? ? cl_image_tag(course.photo.key)
       : cl_image_tag("https://source.unsplash.com/800x500/?food-'#{course.name.split[-2]}'", :type=>"fetch") %>
-              <% render 'shared/square-card', title: course.name, status: "¥#{course.price}", 
+              <% render 'shared/square-card', title: course.name, status: "¥#{number_with_delimiter(course.price)}", 
                       header_image_tag: header_image_tag,
                       user_image_url: "https://source.unsplash.com/100x100/?face-'#{course.chef_profile.user_id}'" %>
             <% end %>

--- a/app/views/shared/_carousel-course.html.erb
+++ b/app/views/shared/_carousel-course.html.erb
@@ -5,6 +5,7 @@
         <div class="cards py-2 px-2">
           <%  s_course.each do |course| %>
             <%= link_to course_path(course) do %>
+              <% initial = course.chef_profile.user.first_name.nil? ? course.chef_profile.user.email[0].upcase : course.chef_profile.user.first_name[0].upcase; %>
               <% header_image_tag = course.photo.attached? ? cl_image_tag(course.photo.key)
                 : cl_image_tag("https://dummyimage.com/1000x500/fff/000&text=Sorry!%20No%20photo%20attached",type: "fetch") %>
               <% user_image_tag = course.chef_profile.user.photo.attached? ? cl_image_tag(course.chef_profile.user.photo.key, class: "card-trip-user avatar-bordered")

--- a/app/views/shared/_carousel-course.html.erb
+++ b/app/views/shared/_carousel-course.html.erb
@@ -6,10 +6,12 @@
           <%  s_course.each do |course| %>
             <%= link_to course_path(course) do %>
               <% header_image_tag = course.photo.attached? ? cl_image_tag(course.photo.key)
-      : cl_image_tag("https://source.unsplash.com/800x500/?food-'#{course.name.split[-2]}'", :type=>"fetch") %>
+                : cl_image_tag("https://dummyimage.com/1000x500/fff/000&text=Sorry!%20No%20photo%20attached",type: "fetch") %>
+              <% user_image_tag = course.chef_profile.user.photo.attached? ? cl_image_tag(course.chef_profile.user.photo.key, class: "card-trip-user avatar-bordered")
+                : cl_image_tag("https://dummyimage.com/200x200/fff/000&text=#{initial}",type: "fetch", class: "card-trip-user avatar-bordered") %>
               <% render 'shared/square-card', title: course.name, status: "¥#{number_with_delimiter(course.price)}", 
                       header_image_tag: header_image_tag,
-                      user_image_url: "https://source.unsplash.com/100x100/?face-'#{course.chef_profile.user_id}'" %>
+                      user_image_tag: user_image_tag %>
             <% end %>
           <% end %>
           <!-- Add empty card to prevent carousel from collapsing when resize the screen (to keep it 4x1 or 2x2)-->

--- a/app/views/shared/_chef-information-card.html.erb
+++ b/app/views/shared/_chef-information-card.html.erb
@@ -1,5 +1,5 @@
 <div class="card-trip mb-3 d-flex flex-column justify-content-between" id="card-trip-flow">
-  <%= header_image_tag %>
+  <%= header_avatar_tag %>
   <div class="card-trip-infos">
     <div class="card-text">
       <h2><%= title %></h2>

--- a/app/views/shared/_course-card.html.erb
+++ b/app/views/shared/_course-card.html.erb
@@ -7,22 +7,6 @@
       <p><%= description %></p>
     </div>
     <h2 class="card-trip-text-padding"><%= status %></h2>
-    <%= cl_image_tag(user_image_url, :type=>"fetch", class: "card-trip-user avatar-bordered") %>
+    <%= user_image_tag %>
   </div>
-</div>
-<div class="d-flex">
-  <% if status == 'confirmed' %>
-    <%= simple_form_for booking do |f| %>
-      <%= f.input :status, as: :hidden, input_html: { value: 'completed'} %>
-      <%= f.submit "I'm happy :)", class: 'btn btn-success btn-sm mx-2' %>
-    <% end %>
-    <%= simple_form_for booking do |f| %>
-      <%= f.input :status, as: :hidden, input_html: { value: 'completed'} %>
-      <%= f.submit 'Could be better :|', class: 'btn btn-warning btn-sm mx-2' %>
-    <% end %>
-    <%= simple_form_for booking do |f| %>
-      <%= f.input :status, as: :hidden, input_html: { value: 'completed'} %>
-      <%= f.submit "I'm not impressed :(", class: 'btn btn-danger btn-sm mx-2' %>
-    <% end %>
-  <% end %>
 </div>

--- a/app/views/shared/_fullpage-card.erb
+++ b/app/views/shared/_fullpage-card.erb
@@ -7,6 +7,6 @@
       <p><%= description %></p>
     </div>
     <h2 class="card-trip-text-padding"><%= status %></h2>
-    <%= cl_image_tag(user_image_url, :type=>"fetch", class: "card-trip-user avatar-bordered") %>
+    <%= user_image_tag %>
   </div>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,7 +12,7 @@
     <% if current_user.photo.attached? %>
       <% cl_image = cl_image_tag(current_user.photo.key, class: "rounded-circle my-auto", width: 24, height: 24) %>
     <% else %>
-      <% initial = current_user.first_name.nil? ? "X" : current_user.first_name[0].upcase; %>
+      <% initial = current_user.first_name.nil? ? chef.user.email[0].upcase : current_user.first_name[0].upcase; %>
       <% cl_image = cl_image_tag("https://dummyimage.com/25x25/fff/000&text=#{initial}",
       type: "fetch", class: "rounded-circle my-auto") %>
     <% end %>

--- a/app/views/shared/_square-card.html.erb
+++ b/app/views/shared/_square-card.html.erb
@@ -5,6 +5,6 @@
       <h2><%= title %></h2>
     </div>
     <h2 class="card-trip-text-padding"><%= status %></h2>
-    <%= cl_image_tag(user_image_url, :type=>"fetch", class: "card-trip-user avatar-bordered") %>
+    <%= user_image_tag %>
   </div>
 </div>


### PR DESCRIPTION
number_with_delimiter adds comma for you automagicly.
![image](https://user-images.githubusercontent.com/78134040/130114882-c518157a-d7ad-4be7-b76f-823a48b80fac.png)

The card that doesn't have an ActiveStorage image will be replaced by "Sorry! No photo attached". This happened because I let the user create a course without upload a photo, which is fixed. This shouldn't happen again in the future (or in the new seed run).

Now every card shows a real photo and avatar from ActiveStorage.

![image](https://user-images.githubusercontent.com/78134040/130116180-a9ca26b1-94c0-4a65-bfb4-ccdab6303d3a.png)

![image](https://user-images.githubusercontent.com/78134040/130115335-da9d0d0f-ba9b-443d-b2cc-29520712b286.png)

And also show the real user(chef)'s address in the card as well (from `user.city` column)

![image](https://user-images.githubusercontent.com/78134040/130115641-61f9cc82-5499-4aca-bcbf-10a919d523ee.png)
