### PR TITLE
add geocoder gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,12 +38,13 @@ gem 'pundit'
 gem 'faker'
 gem 'cloudinary', '~> 1.16.0'
 gem 'pg_search', '~> 2.3.0'
+gem 'geocoder'
 
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'
-  gem 'geocoder'
+
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]


### PR DESCRIPTION
This adds the geocoder gem to the production side of our Gemfile, thus fixing the blocked heroku push.